### PR TITLE
Feature/issue 9/user account creation leaderboard

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -5,6 +5,7 @@ import netlify from '@astrojs/netlify';
 
 // https://astro.build/config
 export default defineConfig({
+  site: 'https://edulaluan.netlify.app',
   integrations: [
     react(),
     tailwind({

--- a/netlify.toml
+++ b/netlify.toml
@@ -9,6 +9,11 @@
 # GITHUB_CLIENT_ID
 # GITHUB_CLIENT_SECRET
 
+# Secrets scanning configuration
+# PUBLIC_* variables are intentionally public (client-side)
+[build.environment]
+  SECRETS_SCAN_OMIT_KEYS = "PUBLIC_SUPABASE_URL,PUBLIC_SUPABASE_PUBLISHABLE_KEY"
+
 [[redirects]]
   from = "/*"
   to = "/index.html"

--- a/src/pages/api/auth/login.ts
+++ b/src/pages/api/auth/login.ts
@@ -24,12 +24,16 @@ export const POST: APIRoute = async ({ request }) => {
         );
       }
 
+      // Determine redirect URL based on environment
+      const siteUrl = import.meta.env.SITE_URL || 'https://edulaluan.netlify.app';
+      const redirectTo = `${siteUrl}/auth/callback`;
+
       const supabase = createClient(supabaseUrl, supabasePublishableKey);
 
       const { data, error } = await supabase.auth.signInWithOAuth({
         provider: 'github',
         options: {
-          redirectTo: 'http://localhost:4321/auth/callback'
+          redirectTo
         }
       });
 

--- a/src/pages/api/auth/login.ts
+++ b/src/pages/api/auth/login.ts
@@ -25,7 +25,8 @@ export const POST: APIRoute = async ({ request }) => {
       }
 
       // Determine redirect URL based on environment
-      const siteUrl = import.meta.env.SITE_URL || 'https://edulaluan.netlify.app';
+      // Astro's import.meta.env.SITE is set in astro.config.mjs
+      const siteUrl = import.meta.env.SITE || 'https://edulaluan.netlify.app';
       const redirectTo = `${siteUrl}/auth/callback`;
 
       const supabase = createClient(supabaseUrl, supabasePublishableKey);


### PR DESCRIPTION
fix github login

## Summary by Sourcery

Update GitHub OAuth login redirect handling and adjust Netlify/Astro configuration for the deployed site.

Bug Fixes:
- Fix GitHub OAuth login by using an environment-based redirect URL instead of a hard-coded localhost callback.

Build:
- Configure Netlify build environment to omit known public keys from secrets scanning and set the Astro site URL for the deployed domain.