### PR TITLE
feat(feedback): integrate Callout feedback widget globally

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -53,6 +53,12 @@ SUPABASE_SECRET_KEY=sk_your-secret-key-here
 # =============================================================================
 
 # =============================================================================
+# Callout Feedback Widget (https://withcallout.com)
+# Get your Project ID from: Dashboard > Your Application > Settings > Project ID
+# =============================================================================
+PUBLIC_CALLOUT_PROJECT_ID=your-project-id-here
+
+# =============================================================================
 # SETUP INSTRUCTIONS:
 # =============================================================================
 # 1. Go to https://supabase.com and create/sign in to your project

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -30,7 +30,7 @@ export default defineConfig({
       // Additional CSP directives
       directives: [
         "default-src 'self'",
-        "connect-src 'self' https://*.supabase.co wss://*.supabase.co",
+        "connect-src 'self' https://*.supabase.co wss://*.supabase.co https://*.withcallout.com",
         "img-src 'self' data: https:",
         "font-src 'self' data: https://fonts.gstatic.com",
         "frame-src 'self'"
@@ -39,6 +39,7 @@ export default defineConfig({
       scriptDirective: {
         // Note: strict-dynamic disabled to allow 'self' for bundled scripts
         // Astro will auto-generate hashes for inline scripts
+        resources: ["'self'", "https://cdn.withcallout.com"]
       },
       // Configure style-src directive for Google Fonts
       styleDirective: {

--- a/netlify.toml
+++ b/netlify.toml
@@ -8,11 +8,12 @@
 # SUPABASE_SECRET_KEY
 # GITHUB_CLIENT_ID
 # GITHUB_CLIENT_SECRET
+# PUBLIC_CALLOUT_PROJECT_ID
 
 # Secrets scanning configuration
 # PUBLIC_* variables are intentionally public (client-side)
 [build.environment]
-  SECRETS_SCAN_OMIT_KEYS = "PUBLIC_SUPABASE_URL,PUBLIC_SUPABASE_PUBLISHABLE_KEY"
+  SECRETS_SCAN_OMIT_KEYS = "PUBLIC_SUPABASE_URL,PUBLIC_SUPABASE_PUBLISHABLE_KEY,PUBLIC_CALLOUT_PROJECT_ID"
 
 [[headers]]
   for = "/*"
@@ -20,7 +21,7 @@
     X-Frame-Options = "SAMEORIGIN"
     Referrer-Policy = "strict-origin-when-cross-origin"
     Permissions-Policy = "geolocation=(), microphone=(), camera=()"
-    Content-Security-Policy = "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' data: https://fonts.gstatic.com; img-src 'self' data: https:; connect-src 'self' https://*.supabase.co wss://*.supabase.co; frame-src 'self';"
+    Content-Security-Policy = "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval' https://cdn.withcallout.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' data: https://fonts.gstatic.com; img-src 'self' data: https:; connect-src 'self' https://*.supabase.co wss://*.supabase.co https://*.withcallout.com; frame-src 'self';"
 
 [[redirects]]
   from = "/*"

--- a/netlify.toml
+++ b/netlify.toml
@@ -21,7 +21,7 @@
     X-Frame-Options = "SAMEORIGIN"
     Referrer-Policy = "strict-origin-when-cross-origin"
     Permissions-Policy = "geolocation=(), microphone=(), camera=()"
-    Content-Security-Policy = "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval' https://cdn.withcallout.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' data: https://fonts.gstatic.com; img-src 'self' data: https:; connect-src 'self' https://*.supabase.co wss://*.supabase.co https://*.withcallout.com; frame-src 'self';"
+    Content-Security-Policy = "default-src 'self'; script-src 'self' https://cdn.withcallout.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' data: https://fonts.gstatic.com; img-src 'self' data: https:; connect-src 'self' https://*.supabase.co wss://*.supabase.co https://*.withcallout.com; frame-src 'self';"
 
 [[redirects]]
   from = "/*"

--- a/src/components/CalloutIdentify.tsx
+++ b/src/components/CalloutIdentify.tsx
@@ -11,11 +11,16 @@ export default function CalloutIdentify() {
     const supabase = createClient();
 
     function identify(user: { id: string; email?: string; user_metadata?: Record<string, unknown> }) {
-      window.Callout?.identify({
+      const payload: { id: string; email?: string; name: string } = {
         id: user.id,
-        email: user.email ?? '',
         name: (user.user_metadata?.full_name as string) ?? user.email ?? '',
-      });
+      };
+
+      if (user.email) {
+        payload.email = user.email;
+      }
+
+      window.Callout?.identify(payload);
     }
 
     // Identify on initial load if already signed in
@@ -23,10 +28,12 @@ export default function CalloutIdentify() {
       if (session?.user) identify(session.user);
     });
 
-    // Re-identify on login, clear on logout
+    // Re-identify on login, destroy widget session on logout
     const { data: { subscription } } = supabase.auth.onAuthStateChange((event, session) => {
       if (event === 'SIGNED_IN' && session?.user) {
         identify(session.user);
+      } else if (event === 'SIGNED_OUT') {
+        window.Callout?.destroy();
       }
     });
 

--- a/src/components/CalloutIdentify.tsx
+++ b/src/components/CalloutIdentify.tsx
@@ -1,0 +1,37 @@
+import { useEffect } from 'react';
+import { createClient } from '../lib/supabase/client';
+
+/**
+ * Identifies logged-in Supabase users with the Callout widget.
+ * Renders nothing — purely handles window.Callout.identify() calls.
+ * Must be mounted with client:only="react" in Layout.astro.
+ */
+export default function CalloutIdentify() {
+  useEffect(() => {
+    const supabase = createClient();
+
+    function identify(user: { id: string; email?: string; user_metadata?: Record<string, unknown> }) {
+      window.Callout?.identify({
+        id: user.id,
+        email: user.email ?? '',
+        name: (user.user_metadata?.full_name as string) ?? user.email ?? '',
+      });
+    }
+
+    // Identify on initial load if already signed in
+    supabase.auth.getSession().then(({ data: { session } }) => {
+      if (session?.user) identify(session.user);
+    });
+
+    // Re-identify on login, clear on logout
+    const { data: { subscription } } = supabase.auth.onAuthStateChange((event, session) => {
+      if (event === 'SIGNED_IN' && session?.user) {
+        identify(session.user);
+      }
+    });
+
+    return () => subscription.unsubscribe();
+  }, []);
+
+  return null;
+}

--- a/src/env.d.ts
+++ b/src/env.d.ts
@@ -6,3 +6,16 @@ declare namespace App {
     // Add custom locals types here
   }
 }
+
+interface Window {
+  CalloutConfig?: {
+    projectId: string;
+  };
+  Callout?: {
+    identify: (user: { id: string; email: string; name?: string; traits?: Record<string, unknown> }) => void;
+    complete: (milestone: string) => void;
+    open: () => void;
+    destroy: () => void;
+    init: (config: { projectId: string }) => void;
+  };
+}

--- a/src/env.d.ts
+++ b/src/env.d.ts
@@ -7,15 +7,19 @@ declare namespace App {
   }
 }
 
-interface Window {
-  CalloutConfig?: {
-    projectId: string;
-  };
-  Callout?: {
-    identify: (user: { id: string; email: string; name?: string; traits?: Record<string, unknown> }) => void;
-    complete: (milestone: string) => void;
-    open: () => void;
-    destroy: () => void;
-    init: (config: { projectId: string }) => void;
-  };
+declare global {
+  interface Window {
+    CalloutConfig?: {
+      projectId: string;
+    };
+    Callout?: {
+      identify: (user: { id: string; email?: string; name?: string; traits?: Record<string, unknown> }) => void;
+      complete: (milestone: string) => void;
+      open: () => void;
+      destroy: () => void;
+      init: (config: { projectId: string }) => void;
+    };
+  }
 }
+
+export {};

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -1,10 +1,13 @@
 ---
+import CalloutIdentify from '../components/CalloutIdentify';
+
 interface Props {
 	title: string;
 	description?: string;
 }
 
 const { title, description = "A smart education resource navigator for Malaysian B40, M40 & T20 communities" } = Astro.props;
+const calloutProjectId = import.meta.env.PUBLIC_CALLOUT_PROJECT_ID;
 ---
 
 <!doctype html>
@@ -55,6 +58,16 @@ const { title, description = "A smart education resource navigator for Malaysian
 </head>
 <body class="font-sans antialiased">
 	<slot />
+	<!-- Callout Feedback Widget (https://withcallout.com) -->
+	{calloutProjectId && (
+		<>
+			<script is:inline define:vars={{ calloutProjectId }}>
+				window.CalloutConfig = { projectId: calloutProjectId };
+			</script>
+			<script src="https://cdn.withcallout.com/widget.js" defer></script>
+			<CalloutIdentify client:only="react" />
+		</>
+	)}
 </body>
 </html>
 


### PR DESCRIPTION
## Summary

Integrates [Callout](https://withcallout.com/) as a sitewide community feedback widget, enabling users to report broken links, inaccurate information, and other issues from any page on EduLaluan — without leaving the site.

## What Changed

| File | Change |
|------|--------|
| \src/components/CalloutIdentify.tsx\ | **NEW** — React component that auto-identifies logged-in Supabase users with Callout |
| \src/layouts/Layout.astro\ | **MOD** — Global widget injection via \window.CalloutConfig\ + CDN script + React identifier |
| \stro.config.mjs\ | **MOD** — CSP: added \cdn.withcallout.com\ to \script-src\, \*.withcallout.com\ to \connect-src\ |
| \
etlify.toml\ | **MOD** — Mirrored CSP additions + \PUBLIC_CALLOUT_PROJECT_ID\ env var docs |
| \.env.example\ | **MOD** — Added \PUBLIC_CALLOUT_PROJECT_ID\ placeholder |
| \src/env.d.ts\ | **MOD** — Added \Window.Callout\ + \Window.CalloutConfig\ TypeScript types |

## Implementation Details

- **CDN script-tag approach** — no npm package; Callout loads from \cdn.withcallout.com/widget.js\
- **Only \PUBLIC_CALLOUT_PROJECT_ID\ required** — widget config uses project ID only
- **Conditionally mounted** — widget only injects when \PUBLIC_CALLOUT_PROJECT_ID\ env var is set (safe for local dev)
- **User identification** — \CalloutIdentify.tsx\ calls \window.Callout.identify()\ on session load and \onAuthStateChange\ so bug reports are automatically attributed to logged-in users
- **CSP compliant** — both Astro experimental CSP and Netlify static header updated

## Activation Steps

1. Add \PUBLIC_CALLOUT_PROJECT_ID\ to **Netlify Dashboard → Environment variables**
2. Redeploy (auto-triggered on merge)

## Testing

- ✅ \stro check\ — 0 TypeScript errors
- ✅ \
pm run build\ — clean build, 0 errors

## Summary by Sourcery

Integrate the Callout feedback widget across the site and link it with Supabase-authenticated users for contextual feedback collection.

New Features:
- Add a global Callout feedback widget that loads on all pages when a project ID environment variable is configured.
- Introduce a React component that identifies logged-in Supabase users to the Callout widget for attributed feedback.

Enhancements:
- Extend global window typings to include Callout configuration and API methods for safer TypeScript usage.
- Update Content Security Policy settings in Astro and Netlify to allow Callout scripts and network requests.
- Exclude the PUBLIC_CALLOUT_PROJECT_ID variable from Netlify secrets scanning configuration.

Documentation:
- Document the PUBLIC_CALLOUT_PROJECT_ID environment variable in the example and Netlify configuration.